### PR TITLE
feat!: Add junction terminal ids to Select Network Graphics

### DIFF
--- a/src/activities/InitializeUtilityNetwork.ts
+++ b/src/activities/InitializeUtilityNetwork.ts
@@ -64,11 +64,11 @@ export class InitializeUtilityNetwork implements IActivityHandler {
                     (utilityNetwork as unknown as Network).networkServiceUrl
                 );
                 IdentityManager.registerToken(agsOauthInfo);
-                await utilityNetwork.load();
             } else {
                 throw new Error("Utility network not found.");
             }
         }
+        await utilityNetwork.load();
         return {
             result: utilityNetwork,
         };

--- a/src/activities/RunUtilityNetworkTrace.ts
+++ b/src/activities/RunUtilityNetworkTrace.ts
@@ -5,8 +5,11 @@ import { trace } from "@arcgis/core/rest/networks/trace";
 import TraceParameters from "@arcgis/core/rest/networks/support/TraceParameters";
 import TraceLocation from "@arcgis/core/rest/networks/support/TraceLocation";
 import TraceResult from "@arcgis/core/rest/networks/support/TraceResult";
+import TraceConfiguration from "esri/networks/support/TraceConfiguration";
+import { MapProvider } from "@geocortex/workflow/runtime/activities/arcgis/MapProvider";
+import { activate } from "@geocortex/workflow/runtime/Hooks";
 
-type TraceConfiguration = TraceParameters["traceConfiguration"];
+//type TraceConfiguration = TraceParameters["traceConfiguration"];
 
 /** An interface that defines the inputs of the activity. */
 export interface RunUtilityNetworkTraceInputs {
@@ -82,6 +85,7 @@ export interface RunUtilityNetworkTraceOutputs {
  * @clientOnly
  * @unsupportedApps GMV, GVH, WAB
  */
+@activate(MapProvider)
 export class RunUtilityNetworkTrace implements IActivityHandler {
     async execute(
         inputs: RunUtilityNetworkTraceInputs
@@ -95,6 +99,7 @@ export class RunUtilityNetworkTrace implements IActivityHandler {
             traceConfiguration,
             resultTypes = [],
         } = inputs;
+
         if (!utilityNetwork) {
             throw new Error("utilityNetwork is required");
         }
@@ -119,17 +124,18 @@ export class RunUtilityNetworkTrace implements IActivityHandler {
                 )?.globalId || namedTraceConfigurationGlobalId;
         }
 
-        let unTraceConfiguration;
-
         if (traceConfiguration && typeof traceConfiguration !== "string") {
-            unTraceConfiguration = {
+            (traceConfiguration as any).toJSON = () => {
                 // A Utlity Network Trace requires a UNTraceConfiguration (if it is defined),
                 // however, the arcgis/core package doesn't expose this module. We use
                 // TraceConfiguration instead but TraceConfiguration.toJSON discards
-                // UNTraceConfiguration properties so we need to create a deep clone and override it.
-                toJSON: () => {
-                    return deepClone(traceConfiguration);
-                },
+                // UNTraceConfiguration properties so we need to create a deep clone and override
+                // the toJSON function to force a full copy.
+                const obj = deepClone(traceConfiguration);
+                obj.toJSON = null;
+                const jsonString = JSON.stringify(obj);
+                const json = JSON.parse(jsonString);
+                return json;
             };
         }
         const traceParams = new TraceParameters({
@@ -137,7 +143,7 @@ export class RunUtilityNetworkTrace implements IActivityHandler {
             moment,
             namedTraceConfigurationGlobalId,
             resultTypes: resultTypes,
-            traceConfiguration: unTraceConfiguration,
+            traceConfiguration: traceConfiguration as any,
             traceLocations,
             traceType,
         });
@@ -152,8 +158,9 @@ export class RunUtilityNetworkTrace implements IActivityHandler {
     }
 }
 
-function deepClone(inObject) {
-    let value, key;
+function deepClone(inObject: any) {
+    let value: any;
+    let key: any;
     if (typeof inObject !== "object" || inObject === null) {
         return inObject; // Return the value if inObject is not an object
     }

--- a/src/activities/RunUtilityNetworkTrace.ts
+++ b/src/activities/RunUtilityNetworkTrace.ts
@@ -5,11 +5,10 @@ import { trace } from "@arcgis/core/rest/networks/trace";
 import TraceParameters from "@arcgis/core/rest/networks/support/TraceParameters";
 import TraceLocation from "@arcgis/core/rest/networks/support/TraceLocation";
 import TraceResult from "@arcgis/core/rest/networks/support/TraceResult";
-import TraceConfiguration from "esri/networks/support/TraceConfiguration";
 import { MapProvider } from "@geocortex/workflow/runtime/activities/arcgis/MapProvider";
 import { activate } from "@geocortex/workflow/runtime/Hooks";
 
-//type TraceConfiguration = TraceParameters["traceConfiguration"];
+type TraceConfiguration = TraceParameters["traceConfiguration"];
 
 /** An interface that defines the inputs of the activity. */
 export interface RunUtilityNetworkTraceInputs {
@@ -143,7 +142,10 @@ export class RunUtilityNetworkTrace implements IActivityHandler {
             moment,
             namedTraceConfigurationGlobalId,
             resultTypes: resultTypes,
-            traceConfiguration: traceConfiguration as any,
+            traceConfiguration:
+                typeof traceConfiguration !== "string"
+                    ? traceConfiguration
+                    : undefined,
             traceLocations,
             traceType,
         });

--- a/src/activities/SelectNetworkGraphics.ts
+++ b/src/activities/SelectNetworkGraphics.ts
@@ -11,6 +11,7 @@ import {
     getValue,
     createNetworkGraphic,
     getNetworkLayerIds,
+    getTerminalIds,
 } from "./utils";
 import WebMap from "@arcgis/core/WebMap";
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
@@ -50,11 +51,6 @@ export interface SelectNetworkGraphicsInputs {
      */
     isFilterBarrier?: boolean;
 
-    /**
-     * @displayName Terminal Id
-     * @description The terminal Id to place the starting location at. Applicable for junction/device sources only.
-     */
-    terminalId?: number;
 }
 
 /** An interface that defines the outputs of the activity. */
@@ -84,7 +80,6 @@ export class SelectNetworkGraphics implements IActivityHandler {
             utilityNetwork,
             locationType,
             isFilterBarrier,
-            terminalId,
         } = inputs;
 
         if (!point) {
@@ -162,6 +157,12 @@ export class SelectNetworkGraphics implements IActivityHandler {
                 queriedGraphic.geometry,
                 point
             );
+            let terminalIds: number[] | undefined = undefined;
+            if(queriedGraphic.geometry && queriedGraphic.geometry.type === 'point') {
+
+                terminalIds = getTerminalIds(queriedGraphic, utilityNetwork)
+            }
+            
             const networkGraphic = createNetworkGraphic(
                 point,
                 queriedGraphic.attributes,
@@ -169,7 +170,7 @@ export class SelectNetworkGraphics implements IActivityHandler {
                 percAlong,
                 locationType,
                 isFilterBarrier,
-                terminalId
+                terminalIds,
             );
             networkGraphics.push(networkGraphic);
         }

--- a/src/activities/__tests__/InitializeUtilityNetwork.test.ts
+++ b/src/activities/__tests__/InitializeUtilityNetwork.test.ts
@@ -29,11 +29,12 @@ const mockProvider = {
 
 jest.mock("@arcgis/core/networks/UtilityNetwork", () => {
     return function () {
-        // no op
+        return {
+            load: jest.fn(),
+        };
     };
 });
 const mockUn = new UtilityNetwork();
-
 jest.mock("@arcgis/core/core/Collection", () => {
     return function () {
         return {
@@ -68,9 +69,6 @@ beforeEach(() => {
 
 describe("InitializeUtilityNetwork", () => {
     describe("execute", () => {
-        const un = new UtilityNetwork();
-        const uns = new Collection<UtilityNetwork>();
-        uns.push(un);
         const context = mockActivityContext();
         it("gets first UtilityNetwork from the WebMap's utilityNetworks collection", async () => {
             const activity = new InitializeUtilityNetwork();

--- a/src/activities/__tests__/RunUtilityNetworkTrace.test.ts
+++ b/src/activities/__tests__/RunUtilityNetworkTrace.test.ts
@@ -43,8 +43,13 @@ jest.mock("@arcgis/core/WebMap", () => {
         };
     };
 });
-jest.mock("@geocortex/workflow/runtime/activities/arcgis/MapProvider");
-
+jest.mock("@geocortex/workflow/runtime/activities/arcgis/MapProvider", () => {
+    return function () {
+        return {
+            featureLayer: {},
+        };
+    };
+});
 jest.mock("@arcgis/core/rest/networks/support/TraceLocation", () => {
     return function () {
         return mockTraceLocation;

--- a/src/activities/utils.ts
+++ b/src/activities/utils.ts
@@ -110,10 +110,7 @@ export function createNetworkGraphic(
         ]
 
     }
-
-
     return networkGraphic;
-
 }
 
 export function getTerminalIds(graphic: Graphic, utilityNetwork: UtilityNetwork): number[] {
@@ -149,12 +146,6 @@ export function getTerminalIds(graphic: Graphic, utilityNetwork: UtilityNetwork)
     }
     return terminalIds;
 }
-
-
-
-
-
-
 
 export function getValue(obj: Record<string, number>, prop: string): any {
     prop = prop.toString().toLowerCase();


### PR DESCRIPTION
I received some feedback from partners that identified a shortcoming of the SelectNetworksGraphics activity.  If an intersecting feature is a utility network junction, it requires a Terminal Id.  This was an input for the activity but doesn't really make sense since we don't know which layers will be selected by the tool.  There is no way to determine which Terminal ID to assoiciate with a given junction, so to ensure full coverage, we return a list of TraceLocations that include all valid Terminal IDs for that layer.  

There is also a bug fix in the InitializeUtiltiyNetwork activity that ensures the UtilityNetwork is loaded when the WebMap provided by the viewer includes a UN collection.