### PR TITLE
build: use Node 16

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,10 +19,10 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Use Node.js 14
+            - name: Use Node.js 16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.x
+                  node-version: 16.x
 
             - run: npm install
 
@@ -49,10 +49,10 @@ jobs:
             - name: Fetch git tags
               run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-            - name: Use Node.js 14
+            - name: Use Node.js 16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.x
+                  node-version: 16.x
 
             - run: npm install
 


### PR DESCRIPTION
The release uses the latest version of semantic-release requires which now requires Node 16. We'll have to update all the activity packs with this change.